### PR TITLE
Update CLI to pull v2.0

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -42,7 +42,7 @@ Usage:
 Examples:
   hfsubset -l divides,nexus        \
            -o ./divides_nexus.gpkg \
-           -r "pre-release"        \
+           -r "v2.0"        \
            -t hl_uri                   \
            "Gages-06752260"
 
@@ -106,7 +106,7 @@ func (opts *SubsetRequest) MarshalJSON() ([]byte, error) {
 
 	jsonmap["layers"] = opts.Layers()
 	jsonmap[key] = opts.IDs()
-	jsonmap["version"] = "pre-release"
+	jsonmap["version"] = "v20" // v20 is v2.0
 	return json.Marshal(jsonmap)
 }
 


### PR DESCRIPTION
`-r` is and has been a noop. Should we just remove it? I updated the usage section so it looks like it is doing something, but it really isnt.

closes #12 